### PR TITLE
F#6 test with eth device

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,8 @@ static struct
   char *program_;
   bool stats_;
   double period;
-} g_options;
+}
+g_options;
 
 string g_robot_desc;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -502,6 +502,8 @@ int main(int argc, char *argv[])
   if (optind < argc)
     Usage("Extra arguments");
 
+  ros::NodeHandle node;
+
   // Catch attempts to quit
   signal(SIGTERM, quitRequested);
   signal(SIGINT, quitRequested);


### PR DESCRIPTION
Closes #6 

Moving most of the ethercat specific stuff out of the main. It has been moved into ros_ethercat_model/ros_ethercat.hpp (see https://github.com/shadow-robot/ros_ethercat/tree/F%2341_combined_robot_hw).

Tested with ronex GPIO.
