### PR TITLE
[ROS-O] do not enforce obsolete c++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ CATKIN_DEPENDS
 )
 SET(GCC_NEWDTAGS_LINK_FLAGS "-Wl,--disable-new-dtags")
 SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_NEWDTAGS_LINK_FLAGS}")
-set (CMAKE_CXX_STANDARD 11)
 add_executable(${PROJECT_NAME} src/main.cpp)
 target_link_libraries(${PROJECT_NAME} rt ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})


### PR DESCRIPTION
C++14 has been the default in gcc/clang since before Ubuntu 18.04 and enforcing an old standard breaks with current versions of log4cxx.

This is the same change as in a myriad of other packages. Required for the ROS-O initiative. Fully compatible with ROS noetic.