### PR TITLE
Fix snapping to the next ms period after an overrun. By making the pe…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
  *  Copyright (c) 2008, Willow Garage, Inc.
  *  All rights reserved.
  *
- *  Modified 2016, by Shadow Robot Company Ltd.
+ *  Modified 2016-2018, 2020, 2022, by Shadow Robot Company Ltd.
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
  *********************************************************************/
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstdarg>
 #include <getopt.h>
@@ -77,7 +78,7 @@ static struct
 {
   char *program_;
   bool stats_;
-  double period;
+  int period; // Period in nanoseconds
 }
 g_options;
 
@@ -301,7 +302,7 @@ void *controlLoop(void */*unused_param*/)  // NOLINT(readability/casting)
 
   struct timespec tick;
   clock_gettime(CLOCK_REALTIME, &tick);
-  ros::Duration durp(g_options.period / 1e+9);
+  ros::Duration durp(static_cast<double>(g_options.period) / 1e+9);
 
   // Snap to the nearest second
   tick.tv_nsec = (tick.tv_nsec / g_options.period + 1) * g_options.period;
@@ -487,7 +488,7 @@ int main(int argc, char *argv[])
         break;
       case 'p':
         // convert period given in msec to nsec
-        g_options.period = fabs(atof(optarg))*1e+6;
+        g_options.period = std:lround(fabs(atof(optarg))*1e+6);
         break;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
         break;
       case 'p':
         // convert period given in msec to nsec
-        g_options.period = std:lround(fabs(atof(optarg))*1e+6);
+        g_options.period = std::lround(fabs(atof(optarg))*1e+6);
         break;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ static struct
 {
   char *program_;
   bool stats_;
-  int period; // Period in nanoseconds
+  int period;  // Period in nanoseconds
 }
 g_options;
 


### PR DESCRIPTION
Fix snapping to the next ms period after an overrun. By making the period be an integer, the existing algoritm works well

## Proposed changes

This file contains the realtime loop for the driver and controllers for every  robot we currently use: hand E, client, UR robots.

The loop is meant to start at integer periods (of it configured period). At the default 1ms period it would meant that we always start at integer ms values, e.g. 1.001000s (1 second and 1 ms), then 1.002000 etcs.

But it wasn't working like that, due to a bug in the code that was supposed to "snap" to the next ms when starting the loop and then again after a loop overrun. The bug was due to the algorithm intending to do an integer division, but actually the period was defined as a double.

This PR defines the period as integer.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
